### PR TITLE
Add API endpoint to export event entrants as JSON

### DIFF
--- a/app/Http/Controllers/API/APIEventsController.php
+++ b/app/Http/Controllers/API/APIEventsController.php
@@ -253,3 +253,36 @@ class APIEventsController extends Controller
 
     }
 }
+
+public function getEventEntrantsExport($eventId)
+{
+    $entrants = \App\Models\Entrant::with('club')
+        ->where('event_id', $eventId)
+        ->get();
+
+    $formatted = $entrants->map(function ($entrant) {
+        return [
+            'id' => $entrant->id,
+            'firstname' => $entrant->firstname,
+            'lastname' => $entrant->lastname,
+            'fullname' => trim("{$entrant->firstname} {$entrant->lastname}"),
+            'email' => $entrant->email,
+            'phone' => $entrant->phone,
+            'club' => optional($entrant->club)->name,
+            'division' => $entrant->division,
+            'class' => $entrant->class,
+            'bow_type' => $entrant->bow_type,
+            'category' => $entrant->category,
+            'age_class' => $entrant->age_class,
+            'notes' => $entrant->notes,
+            'created_at' => $entrant->created_at,
+            'updated_at' => $entrant->updated_at,
+        ];
+    });
+
+    return response()->json([
+        'event_id' => $eventId,
+        'entrant_count' => $formatted->count(),
+        'entrants' => $formatted,
+    ]);
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,3 +20,4 @@ Route::get('event/{eventurl}/{competitionid?}', 'API\APIEventsController@getEven
 
 Route::get('eventtypes', 'API\APIEventsController@getEventTypes');
 
+Route::get('event/{eventid}/entrants/export', 'API\APIEventsController@getEventEntrantsExport');


### PR DESCRIPTION
Setting up API method to retrieve list of entrants, reusing the current mechanism to export entries to a CSV. This will be useful in automating a Google Apps Script to pull this into a spreadsheet for club tournament admin purposes.
Note I have not been able to test this locally, but it is two minor additions and should not break anything!